### PR TITLE
Added ignored comment 

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -12,6 +12,9 @@
 
 //Manifest.json Is a simple JSON file that gives you, the ability to control how your app appears to the user and define its appearance at launch
 
+// eslint-disable-next-line no-restricted-globals
+const ignored = self.__WB_MANIFEST;
+
 const isLocalhost = Boolean(
   window.location.hostname === "localhost" ||
     // [::1] is the IPv6 localhost address.


### PR DESCRIPTION
Added ignored comment as the one requirement is that you keep self.__WB_MANIFEST somewhere in your file, as the Workbox compilation plugin checks for this value when generating a manifest of URLs to precache.